### PR TITLE
Fix /decompile subprocess invoking startup forms and wizards

### DIFF
--- a/mcp_access/maintenance.py
+++ b/mcp_access/maintenance.py
@@ -93,9 +93,22 @@ def ac_decompile_compact(db_path: str) -> dict:
 
     original_size = os.path.getsize(resolved)
 
-    # 1. Close COM session and release the file completely
+    # 1. Close COM session and release the file completely.
+    # Before quitting, temporarily clear StartupForm so the /decompile subprocess
+    # opens the database without invoking any startup form or wizard.
+    # SHIFT simulation alone is unreliable for a separate CREATE_NEW_PROCESS_GROUP
+    # process — Access may check GetKeyState before the injected event is visible.
+    startup_form_backup = None
     try:
         app = _Session.connect(resolved)
+        try:
+            startup_form_backup = app.GetOption("Startup Form")
+            if startup_form_backup:
+                app.SetOption("Startup Form", "")
+                log.info("Cleared StartupForm for /decompile (was %r)", startup_form_backup)
+        except Exception as e:
+            log.warning("Could not clear StartupForm before /decompile: %s", e)
+            startup_form_backup = None
         try:
             app.CloseCurrentDatabase()
         except Exception:
@@ -162,6 +175,13 @@ def ac_decompile_compact(db_path: str) -> dict:
         app2.RunCommand(137)  # acCmdCompileAllModules = 137
     except Exception:
         pass  # compiling is not critical for the compact
+    # Restore StartupForm now that /decompile is done
+    if startup_form_backup:
+        try:
+            app2.SetOption("Startup Form", startup_form_backup)
+            log.info("Restored StartupForm to %r", startup_form_backup)
+        except Exception as e:
+            log.warning("Could not restore StartupForm: %s", e)
     try:
         app2.CloseCurrentDatabase()
     except Exception:


### PR DESCRIPTION
## Summary

`access_decompile_compact` launches a separate `MSACCESS.EXE /decompile` subprocess to strip orphaned p-code. The existing code simulates holding SHIFT (via `keybd_event`) to bypass AutoExec and the startup form, but this is unreliable for `CREATE_NEW_PROCESS_GROUP` child processes — Access may call `GetKeyState` before the injected event is visible in the child's input queue.

In practice, this causes the database's startup form (and any wizard it triggers) to open during the 8-second decompile window, which is confusing and potentially disruptive.

**Fix:** Before quitting the COM session, read and clear the database's `StartupForm` property via `app.SetOption("Startup Form", "")`. This guarantees the subprocess opens without invoking any startup form regardless of whether SHIFT works. The original value is saved in memory and restored (via `SetOption`) after recompile, before the final compact step.

This approach is robust because:
- `SetOption` writes directly to the database property bag (persisted immediately, not subject to `acQuitSaveNone`)
- No dependency on keyboard simulation or process inheritance
- The value is always restored, even if it was already empty (no-op in that case)

## Test plan

- [ ] Set a StartupForm in a test database, run `access_decompile_compact` — confirm no startup form or wizard appears during the decompile window
- [ ] Confirm StartupForm is correctly restored after the compact completes
- [ ] Run on a database with no StartupForm set — confirm no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)