### PR TITLE
Fix ghost Access process left behind after decompile/compact

### DIFF
--- a/mcp_access/core.py
+++ b/mcp_access/core.py
@@ -114,7 +114,7 @@ class _Session:
                 "pywin32 not installed. Run: pip install pywin32"
             )
         log.info("Launching Access.Application...")
-        cls._app = win32com.client.Dispatch("Access.Application")
+        cls._app = win32com.client.DispatchEx("Access.Application")
         try:
             cls._app.Visible = True   # required for VBE to be accessible via COM
         except Exception as e:

--- a/mcp_access/maintenance.py
+++ b/mcp_access/maintenance.py
@@ -232,6 +232,7 @@ def ac_decompile_compact(db_path: str) -> dict:
         )
     except Exception:
         pass
+    time.sleep(1)  # Allow Windows to evict the dead process's ROT entry
 
     decompile_size = os.path.getsize(resolved)
 


### PR DESCRIPTION
## Problem

After `ac_decompile_compact` force-kills the `/decompile` subprocess via `taskkill /F /T`, Access doesn't get to run its cleanup code and leaves a stale entry in the Windows **Running Object Table (ROT)**. The subsequent `Dispatch("Access.Application")` call in `_Session._launch()` latches onto this dead ROT entry, yielding a zombie COM object that passes the `_app.Visible` health check but fails on any database operation (e.g. `app.CurrentData.AllTables` → *"object closed or doesn't exist"*).

This manifests as a hidden Access process that blocks subsequent MCP tool calls until it's manually killed.

## Fix

- **`core.py`**: Replace `win32com.client.Dispatch` with `win32com.client.DispatchEx` in `_Session._launch()`. `DispatchEx` always creates a fresh instance, bypassing the ROT entirely. Since the MCP server manages its own COM session, there is no reason to ever reuse an existing Access process.

- **`maintenance.py`**: Add a 1-second sleep after `taskkill` in `ac_decompile_compact` to allow Windows time to evict the dead process's ROT entry before reconnecting. Belt-and-suspenders alongside the `DispatchEx` fix.

## Testing

Reproduced by running `decompile_compact` followed immediately by `list_objects` — previously failed consistently, now succeeds.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)