### PR TITLE
Add AutomationSecurity=3 to complement Shift key startup bypass

### DIFF
--- a/mcp_access/core.py
+++ b/mcp_access/core.py
@@ -301,7 +301,12 @@ class _Session:
 
         # Call OpenCurrentDatabase in the current thread (COM worker — same
         # apartment that created _app).  The watchdog will dismiss any dialog.
+        # AutomationSecurity=3 (msoAutomationSecurityForceDisable) prevents the
+        # AutoExec macro object from firing at the engine level — complementing
+        # the Shift key approach which works at the UI level.  Restored to 1
+        # (msoAutomationSecurityLow) immediately after open so VBA works normally.
         try:
+            cls._app.AutomationSecurity = 3
             cls._app.OpenCurrentDatabase(path)
         except Exception as e:
             if "already have the database open" in str(e).lower():
@@ -310,6 +315,10 @@ class _Session:
                 raise
         finally:
             _open_done.set()  # signal watchdog to stop
+            try:
+                cls._app.AutomationSecurity = 1  # always restore
+            except Exception:
+                pass
             if shift_held:
                 try:
                     _kbd(VK_SHIFT, 0, KEYEVENTF_KEYUP, 0)  # Release SHIFT


### PR DESCRIPTION
## Summary

- Adds `cls._app.AutomationSecurity = 3` (`msoAutomationSecurityForceDisable`) immediately before `OpenCurrentDatabase()` in `_Session._switch()`, then restores it to `1` in the existing `finally` block alongside the Shift key release
- Provides a second, engine-level suppression layer that complements the existing UI-level Shift key hold: the Shift key bypasses startup code at the UI layer; `AutomationSecurity=3` suppresses named **AutoExec macro objects** at the COM/engine layer before the file even begins opening
- Restoration to `msoAutomationSecurityLow` (`1`) is guaranteed by the `finally` block — VBA macros invoked by the user after open are not affected

## Why both layers matter

| Mechanism | What it stops | When it fires |
|---|---|---|
| Shift key (existing) | All startup code (AutoExec, StartupForm, VBA) at UI level | During `OpenCurrentDatabase` |
| `AutomationSecurity=3` (this PR) | Named AutoExec macro **object** at engine level | Before the file begins loading |

In testing, databases where AutoExec launched a login dialog were only reliably suppressed when **both** mechanisms were active together.

## Test plan

- [ ] Open a database that has an AutoExec macro — confirm no macro dialog appears
- [ ] Open a database that has a StartupForm — confirm form does not block the session
- [ ] After open, run a VBA macro via `access_run_vba` — confirm `AutomationSecurity` was restored (macro executes normally)
- [ ] Verify `AutomationSecurity` is restored even when `OpenCurrentDatabase` raises an exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)