### PR TITLE
Fix inserted line count in _exec_single_replace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.pyc
 *.pyo
 .env
+.mcp.json
+.claude/

--- a/mcp_access/vbe.py
+++ b/mcp_access/vbe.py
@@ -447,7 +447,7 @@ def _exec_single_replace(cm, app, object_type, object_name, start_line, count, n
         decoded = html_mod.unescape(new_code)
         normalized = decoded.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n")
         cm.InsertLines(start_line, normalized)
-        inserted = len(decoded.splitlines())
+        inserted = cm.CountOfLines - (total - count)  # exact: VBE counts trailing blank from trailing \r\n
     end = start_line + count - 1 if count > 0 else start_line
     clamp_note = " (count adjusted)" if clamped else ""
     return {


### PR DESCRIPTION
## Summary

- `splitlines()` treats a trailing `\n` as a line *terminator*, so it does not count the extra blank line that VBE's `InsertLines` creates when `new_code` ends with `\r\n`
- This caused the batch-mode sanity check to fire a spurious `WARNING: Expected N lines after edit, but module has N+k` — one count off per operation whose `new_code` had a trailing newline
- Fix: replace the estimate with an exact measurement — after `InsertLines`, read `cm.CountOfLines` and subtract the pre-insert count (`total - count`), which is the post-delete line count

## Root cause

```python
# Before (undercounts when new_code ends with \n):
inserted = len(decoded.splitlines())

# After (exact — asks VBE directly):
inserted = cm.CountOfLines - (total - count)
```

`total - count` is the module size after any preceding `DeleteLines` call, so the difference is exactly what VBE inserted, trailing blank line and all.

## How it was found

Observed while using `access_vbe_replace_lines` in batch mode to wire up a new multiselect filter combo. Two of the six operations had trailing newlines in `new_code` (intentional blank-line separators between procedures/blocks), producing a consistent +2 discrepancy in the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)