### PR TITLE
fix: detect and reset wedged COM session when a DB closes itself during open

### DIFF
--- a/mcp_access/core.py
+++ b/mcp_access/core.py
@@ -158,6 +158,15 @@ class _Session:
             # Health check: verify COM session is still alive
             try:
                 _ = cls._app.Visible  # cheap COM property access
+                if cls._db_open is not None:
+                    # The app proxy can be alive while the database has been
+                    # closed under us (e.g. by its own startup code). A stale
+                    # _db_open wedges every later CurrentDb/CurrentData call
+                    # with "object is closed or doesn't exist".
+                    if cls._app.CurrentDb() is None:
+                        raise RuntimeError(
+                            f"database no longer open: {cls._db_open}"
+                        )
             except Exception:
                 log.warning("COM session stale — auto-reconnecting...")
                 cls._force_cleanup()
@@ -711,6 +720,43 @@ class _Session:
         if _dialog_screenshots:
             log.warning("A blocking dialog was auto-dismissed. Screenshot: %s",
                         _dialog_screenshots[0])
+
+        # Post-open validation: confirm the database actually stayed open.
+        # Startup code can close the database during an automated open — e.g.
+        # an AutoExec/startup form error path firing because backend links are
+        # broken, with AllowBypassKey=False defeating the SHIFT bypass (the
+        # watchdog's Cancel click then routes through the form's error
+        # handler, which closes the db).  Without this check, _db_open would
+        # record a database that isn't there, and every later call would die
+        # at CurrentDb/CurrentData with "object is closed or doesn't exist",
+        # wedging the session permanently.  Also catches the case where the
+        # "already have the database open" swallow above masked a dead db.
+        db_alive = False
+        try:
+            db_alive = cls._app.CurrentDb() is not None
+        except Exception as e_val:
+            log.warning("Post-open validation raised: %s", e_val)
+        if not db_alive:
+            log.error(
+                "Database closed itself during open: %s — resetting session",
+                path,
+            )
+            # quit() does the right thing for both cases: spawned instances
+            # are quit (taskkill fallback included); attached instances are
+            # released without touching the user's Access.
+            try:
+                cls.quit()
+            except Exception as e_q:
+                log.warning("Session teardown after failed open: %s", e_q)
+                cls._force_cleanup()
+            raise RuntimeError(
+                f"Database closed itself while opening: {path}. Its startup "
+                "code (AutoExec / startup form) most likely failed and closed "
+                "the database — common causes: missing backend table links, "
+                "or AllowBypassKey=False defeating the SHIFT bypass. The COM "
+                "session has been reset; open the file manually in Access "
+                "while holding SHIFT to investigate."
+            )
 
         cls._db_open = path
 


### PR DESCRIPTION
## Problem

If a database's startup code closes the database during an automated open, the session singleton is left permanently wedged:

- `_switch()` records `_db_open` without verifying the database actually stayed open. Every subsequent tool call then fails with `The expression you entered refers to an object that is closed or doesn't exist` at `CurrentDb`/`CurrentData`.
- `connect()`'s health check only probes `app.Visible`, which succeeds on an Access instance whose database has been closed under it, so the wedge is never detected.
- Because `quit()` on attached instances only releases the COM reference, `access_close` + reconnect re-attaches (via `GetActiveObject`) to the same broken instance — an unrecoverable loop until the Access process is manually killed.

Observed in the wild with a frontend whose startup form errors when the synthetic SHIFT keypress gets eaten (e.g. the user is typing during the open): the dialog watchdog's Cancel click routes through the form's error handler, which closes the database. The open "succeeds" from COM's perspective, and every call afterward dies.

## Fix

1. **`_switch()`**: after `OpenCurrentDatabase`, validate `CurrentDb()` is alive. On failure, tear the session down via the existing `quit()` (correct for both spawned and attached instances) and raise a clear, actionable `RuntimeError` naming the likely causes (AutoExec/startup-form failure, broken backend links, `AllowBypassKey=False`). This also covers the case where the `"already have the database open"` swallow masked a dead db.
2. **`connect()`**: when `_db_open` is set, the health check now also verifies `CurrentDb()` is not None, triggering the existing `_force_cleanup()` auto-reconnect path.

## Verification

Ran live against Access 16.0 (Microsoft 365) with a standalone harness driving `_Session` directly:

| Check | Result |
| --- | --- |
| Happy-path open, `CurrentDb` resolves | PASS |
| DB closed behind the session's back → `connect()` detects and recovers | PASS |
| Silently-failing open (no-op `OpenCurrentDatabase` proxy, mimicking a self-closing DB) → `RuntimeError` raised | PASS |
| Session state fully reset after the failure (`_app is None`) | PASS |
| Fresh `connect()` succeeds after the reset | PASS |

`python -m py_compile` clean; the existing test suite (lint/VBE helpers) does not cover session logic and is unaffected.

## Possible follow-up (not in this PR)

While reproducing this we also observed that attached instances released by `quit()` accumulate as orphaned `msaccess.exe` processes that later launches silently re-attach to. The fix above stops the *wedged* variant of that loop, but a deliberate strategy for orphaned-but-healthy instances might be worth discussing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)