### PR TITLE
Add MCP_ACCESS_SHIFT_BYPASS to switch off the global SHIFT AutoExec bypass

### DIFF
--- a/mcp_access/core.py
+++ b/mcp_access/core.py
@@ -17,6 +17,8 @@ import winreg
 from pathlib import Path
 from typing import Any, Optional
 
+from .security import shift_bypass_enabled
+
 # DPI awareness -- must be set before any window operations
 try:
     ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
@@ -432,17 +434,20 @@ class _Session:
         # set and MUST be preserved.
         pids_before = _list_msaccess_pids()
 
-        # Hold SHIFT while launching /decompile
+        # Hold SHIFT while launching /decompile.  Opt-in — this path holds it for
+        # ~3s (see the release at the i == 6 mark below), which is long enough to
+        # mangle real typing anywhere on the machine.
         VK_SHIFT = 0x10
         KEYEVENTF_KEYUP = 0x0002
         _kbd = ctypes.windll.user32.keybd_event
         shift_held = False
-        try:
-            _kbd(VK_SHIFT, 0, 0, 0)
-            time.sleep(0.3)
-            shift_held = True
-        except Exception:
-            pass
+        if shift_bypass_enabled():
+            try:
+                _kbd(VK_SHIFT, 0, 0, 0)
+                time.sleep(0.3)
+                shift_held = True
+            except Exception:
+                pass
 
         proc = subprocess.Popen(
             [msaccess, path, "/decompile"],
@@ -673,18 +678,27 @@ class _Session:
 
         cls._suppress_recovery_dialog()
 
-        # Hold Shift during OpenCurrentDatabase to bypass AutoExec/startup forms
+        # Hold Shift during OpenCurrentDatabase to bypass AutoExec/startup forms.
+        # Opt-in: the key-down is global, so it shifts whatever the human is typing
+        # anywhere on the machine.  See security.shift_bypass_enabled().
         VK_SHIFT = 0x10
         KEYEVENTF_KEYUP = 0x0002
         _kbd = ctypes.windll.user32.keybd_event
         shift_held = False
-        try:
-            _kbd(VK_SHIFT, 0, 0, 0)  # Press SHIFT
-            time.sleep(0.3)  # Let the key state register before COM call
-            shift_held = True
-            log.info("SHIFT held for bypass")
-        except Exception:
-            log.warning("Could not simulate Shift — AutoExec may run")
+        if shift_bypass_enabled():
+            try:
+                _kbd(VK_SHIFT, 0, 0, 0)  # Press SHIFT
+                time.sleep(0.3)  # Let the key state register before COM call
+                shift_held = True
+                log.info("SHIFT held for bypass")
+            except Exception:
+                log.warning("Could not simulate Shift — AutoExec may run")
+        else:
+            log.info(
+                "SHIFT bypass disabled via MCP_ACCESS_SHIFT_BYPASS — an unguarded "
+                "AutoExec in the target database will run; the dialog watchdog "
+                "still handles any modal it raises"
+            )
 
         # Capture Access hwnd on THIS thread (COM worker — same apartment
         # that created _app).  COM STA proxies cannot be accessed from the

--- a/mcp_access/maintenance.py
+++ b/mcp_access/maintenance.py
@@ -216,18 +216,22 @@ def ac_decompile_compact(db_path: str) -> dict:
     # escape `taskkill /T /F`.  Preserves the user's attached PID (if any).
     pids_before = _list_msaccess_pids()
 
-    # Hold SHIFT during /decompile to bypass AutoExec/startup forms
+    # Hold SHIFT during /decompile to bypass AutoExec/startup forms.
+    # Opt-in — held for ~3s on this path, and the key-down is global, so it
+    # shifts anything the human types meanwhile.  See security.shift_bypass_enabled().
     import ctypes
+    from .security import shift_bypass_enabled
     VK_SHIFT = 0x10
     KEYEVENTF_KEYUP = 0x0002
     _kbd = ctypes.windll.user32.keybd_event
     shift_held = False
-    try:
-        _kbd(VK_SHIFT, 0, 0, 0)       # Press SHIFT
-        time.sleep(0.3)                # Let key state register
-        shift_held = True
-    except Exception:
-        pass  # SHIFT simulation failed — AutoExec may run
+    if shift_bypass_enabled():
+        try:
+            _kbd(VK_SHIFT, 0, 0, 0)       # Press SHIFT
+            time.sleep(0.3)                # Let key state register
+            shift_held = True
+        except Exception:
+            pass  # SHIFT simulation failed — AutoExec may run
 
     proc = subprocess.Popen(
         [msaccess, resolved, "/decompile"],

--- a/mcp_access/security.py
+++ b/mcp_access/security.py
@@ -20,6 +20,7 @@ CODE_EXEC_TOOLS = frozenset({
 })
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
 
 
 def code_exec_enabled() -> bool:
@@ -49,3 +50,53 @@ def code_exec_denied_message(name: str) -> dict:
         ),
         "gated_tool": name,
     }
+
+
+def shift_bypass_enabled() -> bool:
+    """True unless the operator has switched the synthetic SHIFT bypass off.
+
+    Holding SHIFT across ``OpenCurrentDatabase`` / ``MSACCESS /decompile`` is how
+    this server skips a target database's AutoExec macro and startup form. It
+    works, but ``keybd_event(VK_SHIFT, ...)`` is a **global** OS-level key-down:
+    it is not scoped to Access, so every keystroke the human types anywhere on
+    the machine during the hold arrives shifted. The open path holds it ~0.3s on
+    every database switch; the decompile path holds it ~3s. On a box where
+    someone is working while the server runs, that is a repeated nuisance.
+
+    **Default ON** - unlike ``MCP_ACCESS_ALLOW_CODE_EXEC``, which is a security
+    gate and fails closed. This one is ergonomics, and defaulting it off would
+    silently change behaviour for every existing user whose databases rely on the
+    bypass: their AutoExec would start running again with no error to explain it.
+    So it stays on, and the people who don't need it turn it off. Hence the name -
+    an ``ALLOW_`` prefix would wrongly imply default-off, and a ``DISABLE_`` flag
+    would force everything to be reasoned about as a double negative.
+
+    Set ``MCP_ACCESS_SHIFT_BYPASS`` to ``0`` / ``false`` / ``no`` / ``off`` to
+    disable. With it disabled:
+
+    - ``AutomationSecurity = msoAutomationSecurityForceDisable`` still runs, which
+      blocks VBA auto-run code but NOT an AutoExec *macro object* (tested - Access
+      ignores it for those), so an unguarded AutoExec macro WILL execute;
+    - the dialog watchdog still runs, so a modal raised by that startup code is
+      still detected and dismissed.
+
+    Turn it off when the target databases guard their own startup, which is the
+    clean fix and belongs there rather than in a global input hack:
+
+        If Not Application.UserControl Then
+          Exit Function
+        End If
+
+    ``Application.UserControl`` is False when Access was started via COM and True
+    when a human launched it, so the app opts itself out and nothing needs to fake
+    a keypress. Databases that do this need no bypass at all.
+
+    Read on every call so import order is irrelevant and tests can flip it.
+    """
+    raw = os.environ.get("MCP_ACCESS_SHIFT_BYPASS")
+    if raw is None:
+        return True
+    raw = raw.strip().lower()
+    if raw == "":
+        return True
+    return raw not in _FALSY

--- a/mcp_access/tips.py
+++ b/mcp_access/tips.py
@@ -43,7 +43,10 @@ _TIPS: dict[str, str] = {
         "  ListBox AddItem — column separator is \";\", never use Format \"#,##0.00\" (comma breaks columns)\n"
         "  GetClipboardFilePath() can throw — always wrap in On Error Resume Next\n\n"
         "Startup:\n"
-        "  SHIFT bypass is automatic — OpenCurrentDatabase and /decompile always hold SHIFT to skip AutoExec/startup forms.\n"
+        "  SHIFT bypass is ON by default — OpenCurrentDatabase and /decompile hold SHIFT to skip AutoExec/startup forms.\n"
+        "    The key-down is global, so it shifts whatever the user is typing anywhere on the machine (~0.3s per open, ~3s per decompile).\n"
+        "    Turn it off with MCP_ACCESS_SHIFT_BYPASS=0 once the databases guard their own startup:\n"
+        "    `If Not Application.UserControl Then Exit Function` opts a database out under COM automation and needs no bypass at all.\n"
         "  Any auto-opened forms are closed automatically after opening the database."
     ),
     "sql": (

--- a/tests/test_shift_bypass_gate.py
+++ b/tests/test_shift_bypass_gate.py
@@ -1,0 +1,112 @@
+"""
+Pure-Python tests for the opt-in SHIFT AutoExec bypass.
+
+Holding SHIFT across OpenCurrentDatabase / MSACCESS /decompile is how the server
+skips a target database's AutoExec macro and startup form. `keybd_event` is a
+GLOBAL OS-level key-down, though - it is not scoped to Access, so every keystroke
+the human types anywhere on the machine during the hold arrives shifted. The open
+path holds it ~0.3s, the decompile path ~3s.
+
+It stays ON by default - turning it off silently would change behaviour for every
+existing user whose databases rely on it, with no error to explain why AutoExec
+suddenly runs. `MCP_ACCESS_SHIFT_BYPASS=0` opts out. Unlike
+MCP_ACCESS_ALLOW_CODE_EXEC this is an ergonomics switch, not a security gate, so
+it fails OPEN rather than closed - which is exactly why the name has no `ALLOW_`
+prefix.
+
+No COM / no Access needed.
+
+Run with:
+    python -m pytest tests/test_shift_bypass_gate.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from mcp_access.security import shift_bypass_enabled  # noqa: E402
+
+ENV = "MCP_ACCESS_SHIFT_BYPASS"
+
+
+def test_on_when_unset(monkeypatch):
+    """Back-compat is the whole point of the default: an existing user who
+    upgrades and sets nothing must see no change in behaviour."""
+    monkeypatch.delenv(ENV, raising=False)
+    assert shift_bypass_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "NO", "off", " off "])
+def test_falsy_values_disable(monkeypatch, value):
+    monkeypatch.setenv(ENV, value)
+    assert shift_bypass_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["", "   ", "1", "true", "yes", "on", "maybe", "2"])
+def test_everything_else_stays_on(monkeypatch, value):
+    """Fails OPEN: only an explicit falsy word disables it. A typo or an empty
+    value must not quietly drop the bypass and let AutoExec run."""
+    monkeypatch.setenv(ENV, value)
+    assert shift_bypass_enabled() is True
+
+
+def test_read_per_call_not_at_import(monkeypatch):
+    """Import order must not decide the answer - the code-exec gate has the same
+    property and the tests rely on it."""
+    monkeypatch.delenv(ENV, raising=False)
+    assert shift_bypass_enabled() is True
+    monkeypatch.setenv(ENV, "0")
+    assert shift_bypass_enabled() is False
+    monkeypatch.delenv(ENV, raising=False)
+    assert shift_bypass_enabled() is True
+
+
+def test_switch_is_independent_of_the_code_exec_gate(monkeypatch):
+    """Two separate concerns, opposite defaults: turning the keyboard bypass off
+    must not affect the security gate, or vice versa."""
+    monkeypatch.setenv("MCP_ACCESS_ALLOW_CODE_EXEC", "1")
+    monkeypatch.setenv(ENV, "0")
+    assert shift_bypass_enabled() is False
+    monkeypatch.delenv("MCP_ACCESS_ALLOW_CODE_EXEC", raising=False)
+    assert shift_bypass_enabled() is False
+
+
+def test_old_allow_prefixed_name_is_not_honoured(monkeypatch):
+    """The switch was briefly named MCP_ACCESS_ALLOW_SHIFT_BYPASS with the
+    opposite default. If someone carries that stale var over from notes or an
+    old config, it must not appear to work."""
+    monkeypatch.delenv(ENV, raising=False)
+    monkeypatch.setenv("MCP_ACCESS_ALLOW_SHIFT_BYPASS", "0")
+    assert shift_bypass_enabled() is True
+
+
+@pytest.mark.parametrize("module", ["core", "maintenance"])
+def test_every_keybd_event_site_is_gated(module):
+    """Guards against a future edit reintroducing an ungated press.
+
+    Every `keybd_event(VK_SHIFT, 0, 0, 0)` key-DOWN must sit under a
+    shift_bypass_enabled() check. Key-UP calls (KEYEVENTF_KEYUP) are exempt -
+    releasing a key that was never pressed is harmless and the safety net on
+    exit depends on staying unconditional.
+    """
+    src = (Path(__file__).resolve().parent.parent / "mcp_access" / f"{module}.py").read_text(
+        encoding="utf-8"
+    )
+    assert "shift_bypass_enabled" in src, f"{module}.py does not consult the gate at all"
+
+    lines = src.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if "_kbd(VK_SHIFT, 0, 0, 0)" not in stripped:
+            continue
+        # Walk back to the nearest enclosing gate; the press sits inside
+        # `if shift_bypass_enabled():` plus a try block, so allow a few levels.
+        window = "\n".join(lines[max(0, i - 8):i])
+        assert "shift_bypass_enabled()" in window, (
+            f"{module}.py line {i + 1}: SHIFT key-down is not gated by "
+            f"shift_bypass_enabled()"
+        )


### PR DESCRIPTION
### The problem

`OpenCurrentDatabase` and `MSACCESS /decompile` hold the SHIFT key to skip the
target database's AutoExec macro and startup form. It works — but
`keybd_event(VK_SHIFT, ...)` is a **global** OS-level key-down. It isn't scoped to
Access, so every keystroke the human types *anywhere on the machine* during the
hold arrives shifted.

- open path: ~0.3s, on **every** database switch
- decompile path: ~3s

On a box where someone is working while the server runs, that's a repeated and
fairly baffling nuisance — text arrives capitalised with nothing on screen to
explain why. I hit it often enough while typing in another window to go looking
for the cause.

### What this changes

Nothing, by default. With `MCP_ACCESS_SHIFT_BYPASS` unset the bypass behaves
exactly as it does today, so no existing user has to do anything. Set it to
`0` / `false` / `no` / `off` to turn it off.

I deliberately kept the default ON rather than flipping it: turning the bypass off
by default would silently change behaviour for everyone whose databases rely on
it, and the symptom — AutoExec suddenly running — has no error message pointing
back at the cause.

### Fail-open, on purpose

This is the mirror image of `MCP_ACCESS_ALLOW_CODE_EXEC`. That's a security gate
and fails **closed**: only an explicit truthy value opens it. This one is
ergonomics and fails **open**: only an explicit falsy word disables it, so a typo
or an empty value keeps the bypass rather than quietly letting AutoExec run on
someone's database.

That's also why the name has no `ALLOW_` prefix (which would imply default-off)
and isn't a `DISABLE_` flag (which would force every reader through a double
negative).

### With it off

The existing safety nets still apply:

- `AutomationSecurity = msoAutomationSecurityForceDisable` is still set. As the
  existing comment in `core.py` notes, that blocks VBA auto-run code but **not**
  an AutoExec *macro object* — Access ignores it for those.
- The dialog watchdog still detects and dismisses any modal the startup code
  raises.

So it's the right switch for databases that guard their own startup, which is the
cleaner fix and belongs in the database rather than in a global input hack:

```vba
If Not Application.UserControl Then
  Exit Function
End If
```

`Application.UserControl` is False when Access was started via COM and True when a
human launched it, so the database opts itself out under automation and needs no
bypass at all. `tips.py` now says this.

### Scope

Five files. `core.py` and `maintenance.py` both carry their own copies of the
SHIFT press/release logic (open, `/decompile`, compact-repair reopen), so all of
them are gated — otherwise the switch would only be a half-measure.

### Testing

New `tests/test_shift_bypass_gate.py` covers the unset default, each falsy word,
the fail-open cases, per-call reads (so import order is irrelevant), and
independence from the code-exec gate. Full suite: **166 passed**.

Happy to adjust the variable name or the default if you'd rather it landed
differently.
