### PR TITLE
fix: false 'NOT compiled' from a failed compile trigger + modal dialog wedging delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@
     `code_pane` diagnostic fields.
   Pure-Python tests for the pane-selection logic in
   `tests/test_compile_trigger.py`.
+- **`_save_all_modules` no longer wedges `access_delete_object` behind a modal
+  dialog.** `RunCommand(280)` (`acCmdSaveAllModules`) does not always report
+  "not available now" as a trappable 2046 — when Access is not the foreground
+  application (typically because the VBE has focus, e.g. right after
+  `access_compile_vba` activated a code pane) it surfaces as a **modal dialog**
+  that blocks the COM call until a human clicks OK. Observed in the field as a
+  *"command 'SaveAllModules' isn't available"* box popping up during a routine
+  module delete. `RunCommand` is one of the blocking calls the dialog watchdog
+  exists for, so it now runs under one; a dismissed dialog means the command
+  did not run, so the per-module `DoCmd.Save` fallback executes instead of
+  trusting a save that never happened.
 
 ## 0.7.52 — 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`access_compile_vba` no longer misreports a failed compile *trigger* as a
+  compile *error* in the user's code.** The tool deliberately dirties the
+  project (step 0b) so `Application.IsCompiled` can serve as the success
+  signal, then triggers compilation by `Execute()`-ing the VBE *Debug >
+  Compile* menu item. That item acts on the **active** project and is only
+  reliably enabled when one of its code panes has focus — so with no pane
+  active the trigger could raise `DISP_E_EXCEPTION` (-2147352567), silently
+  no-op, or compile the wrong project entirely (after a decompile/compact the
+  active project is typically the `acwzmain` wizard library). Every one of
+  those paths left the deliberately-dirtied `IsCompiled=False` standing and
+  produced the false *"VBA project is NOT compiled … missing reference,
+  undeclared variable, or type mismatch"* — while a manual Debug > Compile of
+  the same project succeeded (repeated field reports). Now:
+  - a code pane of the **current database's** project is activated before the
+    trigger (`_ensure_code_pane`, standard modules preferred — no Design-view
+    side effects), which both enables the menu item and makes it target the
+    right project;
+  - the step-0b dirty-marking resolves the project via `_get_vb_project`
+    instead of `VBE.ActiveVBProject`, so it can no longer dirty `acwzmain`
+    while reading `IsCompiled` from the user's project;
+  - a disabled menu item falls back to `RunCommand` instead of executing a
+    control known to fail;
+  - an exception from the trigger is reported as *"could not run the compile
+    command"* — explicitly **not** a code error — and the residual
+    `IsCompiled=False`-with-no-dialog case now states both possible causes
+    (dialog-less compile error vs. trigger no-op) and tells the caller to
+    cross-check with Debug > Compile. Both results carry `trigger` and
+    `code_pane` diagnostic fields.
+  Pure-Python tests for the pane-selection logic in
+  `tests/test_compile_trigger.py`.
+
 ## 0.7.52 — 2026-07-21
 
 **`access_vbe_patch_proc` stops being the one write tool without a safety net.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,6 +545,31 @@ unchanged, its wrappers just delegate now.
 inside the loop could ever have flagged it (the "Statement invalid inside Type
 block" trap already documented under VBA Language Gotchas).
 
+## access_compile_vba trigger hardening (unreleased)
+
+`ac_compile_vba` reads `Application.IsCompiled` as its success signal after
+**deliberately dirtying the project** (step 0b) — so any path where the
+Debug > Compile trigger silently fails leaves `IsCompiled=False` and used to
+be misreported as a compile error in the user's code ("missing reference,
+undeclared variable, or type mismatch") while manual Debug > Compile
+succeeded.
+
+- **`_ensure_code_pane(app)`** runs before the trigger: opens/activates a code
+  pane of the CURRENT database's project (via `_get_vb_project`, standard
+  modules preferred). Debug > Compile acts on the ACTIVE project and is only
+  reliably enabled with a code pane focused; after a decompile/compact the
+  active project is often `acwzmain`. Do NOT remove this step — without it
+  `Execute()` raises DISP_E_EXCEPTION, no-ops, or compiles the wizard library.
+- Step 0b uses `_get_vb_project`, NOT `VBE.ActiveVBProject` — same
+  wrong-project reasoning as `access_vbe_check_syntax`.
+- A disabled menu item falls back to `RunCommand(AC_CMD_COMPILE)`.
+- Trigger exception ⇒ "could not run the compile command" (NOT a code error).
+  `IsCompiled=False` with no dialog and no block mismatches ⇒ message states
+  BOTH possible causes and tells the caller to cross-check manually. Both
+  results carry `trigger` + `code_pane` diagnostics. Do NOT restore the old
+  unconditional "missing reference…" wording — it was a repeated field false
+  alarm.
+
 ## Code-execution gate (v0.7.51)
 
 `mcp_access/security.py` is the single source of truth for the opt-in gate that

--- a/mcp_access/code.py
+++ b/mcp_access/code.py
@@ -161,12 +161,51 @@ def _save_all_modules(app) -> None:
     RunCommand 280 can raise 2046 'not available now' without an applicable
     module context -- fall back to saving loaded modules one by one.
     Never raises.
+
+    The 'not available now' case does NOT always come back as a trappable
+    2046: when Access is not the foreground application (typically because
+    the VBE has focus -- e.g. straight after ac_compile_vba activated a code
+    pane) it surfaces as a MODAL dialog instead, which blocks the COM call
+    until a human clicks OK.  RunCommand is one of the blocking calls the
+    dialog watchdog exists for, so run it under one; the per-module fallback
+    below then does the actual saving.  Do NOT drop the watchdog: without it
+    a routine ac_delete_object can wedge the session behind a dialog the
+    caller never sees.
     """
+    import threading
+    from .vba_exec import _dialog_watchdog
+
+    stop_event = threading.Event()
+    dismissed: list = []
+    watchdog = None
+    try:
+        _h = app.hWndAccessApp
+        hwnd = int(_h() if callable(_h) else _h)
+        watchdog = threading.Thread(
+            target=_dialog_watchdog,
+            args=[hwnd, stop_event, dismissed, [], 0.5],
+            daemon=True,
+        )
+        watchdog.start()
+    except Exception:
+        watchdog = None
+    ran_ok = False
     try:
         app.RunCommand(280)
-        return
+        ran_ok = True
     except Exception:
         pass
+    finally:
+        stop_event.set()
+        # Join before reading `dismissed`: dismissing the dialog is what
+        # unblocks RunCommand, so the main thread can get here before the
+        # watchdog thread has recorded the dismissal.
+        if watchdog is not None:
+            watchdog.join(timeout=2)
+    # A dismissed dialog means the command did not run -- fall through to
+    # the per-module loop instead of trusting a save that never happened.
+    if ran_ok and not dismissed:
+        return
     try:
         mods = app.CurrentProject.AllModules
         for i in range(mods.Count):

--- a/mcp_access/compile.py
+++ b/mcp_access/compile.py
@@ -7,7 +7,7 @@ import threading
 import time
 from typing import Optional
 
-from .core import _Session, log
+from .core import _Session, log, _get_vb_project
 from .constants import AC_CMD_COMPILE
 
 
@@ -474,6 +474,64 @@ def _check_blocks_in_module(module_name: str, lines: list, errors: list):
         i += 1
 
 
+def _ensure_code_pane(app) -> dict:
+    """Open and activate a code pane in the CURRENT database's VBA project.
+
+    Why this exists (the false "NOT compiled" report): ``ac_compile_vba``
+    triggers compilation by ``Execute()``-ing the VBE *Debug > Compile* menu
+    item.  That item acts on the **active** project and is only reliably
+    enabled when one of its code panes has focus.  Two silent failure modes
+    follow when no pane of the target project is active:
+
+    * the item is disabled/unavailable — ``Execute()`` then raises
+      ``DISP_E_EXCEPTION`` (-2147352567) or simply does nothing;
+    * the active project is a *different* one — after a decompile/compact
+      cycle it is typically the ``acwzmain`` wizard library — so the wrong
+      project gets compiled.
+
+    In both cases the deliberate dirty-marking in step 0b of
+    ``ac_compile_vba`` leaves ``Application.IsCompiled`` False, which used to
+    be misreported as "missing reference, undeclared variable, or type
+    mismatch" in the USER's code (field report: manual Debug > Compile
+    succeeded while the tool claimed the project was broken).
+
+    Prefers a standard module (showing its pane has no Design-view side
+    effects); falls back to any component with code.  Purely best-effort:
+    returns ``{"ok": bool, "project": str|None, "detail": str}`` for
+    diagnostics — callers must not raise on ``ok=False``.
+    """
+    try:
+        proj = _get_vb_project(app)
+    except Exception as exc:
+        return {"ok": False, "project": None, "detail": f"no VBProject: {exc}"}
+    proj_name = None
+    try:
+        proj_name = proj.Name
+    except Exception:
+        pass
+    try:
+        comps = list(proj.VBComponents)
+    except Exception as exc:
+        return {"ok": False, "project": proj_name,
+                "detail": f"VBComponents not enumerable: {exc}"}
+    # Two passes: standard modules (Type 1) first, then anything with code.
+    for std_only in (True, False):
+        for comp in comps:
+            try:
+                if std_only and comp.Type != 1:
+                    continue
+                cm = comp.CodeModule
+                if cm.CountOfLines == 0:
+                    continue
+                cm.CodePane.Show()  # creates the pane if needed + activates it
+                return {"ok": True, "project": proj_name,
+                        "detail": f"code pane opened: {comp.Name}"}
+            except Exception:
+                continue
+    return {"ok": False, "project": proj_name,
+            "detail": "no component with code found"}
+
+
 def _read_dialog_text(hwnd_access: int) -> Optional[str]:
     """Read text from an Access/VBE error dialog without dismissing it.
     Returns the static text content or None if no dialog found."""
@@ -556,11 +614,18 @@ def ac_compile_vba(db_path: str, timeout: Optional[int] = None) -> dict:
 
     Uses VBE CommandBars to trigger compilation (reliable for ALL modules
     including form/report, unlike RunCommand(126) which silently skips them).
+    Before triggering, a code pane of the current database's project is
+    activated (`_ensure_code_pane`) — Debug > Compile acts on the ACTIVE
+    project and is only reliably enabled with a code pane focused; without
+    this the trigger could raise, no-op, or compile the wrong project (e.g.
+    acwzmain after a decompile), all misreported as user compile errors.
 
     A watchdog reads the error dialog text via Win32 GetWindowText before
     dismissing it, and VBE.ActiveCodePane gives the exact error location.
 
-    Fallback: block mismatch parser + structural verification.
+    Fallback: block mismatch parser + structural verification.  A failure to
+    RUN the compile command is reported as such (`trigger`, `code_pane`
+    diagnostic fields), distinct from the code failing to compile.
     Returns dict with status + optional error_detail, error_location.
     """
     from pathlib import Path
@@ -574,13 +639,16 @@ def ac_compile_vba(db_path: str, timeout: Optional[int] = None) -> dict:
     app = _Session.connect(db_path)
 
     # 0b. Force project to "not compiled" state.
+    #     _get_vb_project, NOT VBE.ActiveVBProject: after the auto-decompile
+    #     above, the active project is often the acwzmain wizard library —
+    #     dirtying that would leave OUR project's IsCompiled untouched.
     vbe_was_visible = False
     try:
         vbe_was_visible = bool(app.VBE.MainWindow.Visible)
     except Exception:
         pass
     try:
-        _proj = app.VBE.ActiveVBProject
+        _proj = _get_vb_project(app)
         for _comp in _proj.VBComponents:
             if _comp.Type == 1 and _comp.CodeModule.CountOfLines > 0:
                 _cm = _comp.CodeModule
@@ -596,8 +664,19 @@ def ac_compile_vba(db_path: str, timeout: Optional[int] = None) -> dict:
     except Exception:
         pass
 
+    # 1b. Activate a code pane of OUR project.  Debug > Compile acts on the
+    #     ACTIVE project and is only reliably enabled with a code pane
+    #     focused — without this the Execute() below can raise
+    #     DISP_E_EXCEPTION, silently no-op, or compile the wrong project,
+    #     all of which used to surface as a false "NOT compiled" error.
+    pane_info = _ensure_code_pane(app)
+    if not pane_info["ok"]:
+        log.warning("Could not activate a code pane before compile: %s",
+                    pane_info["detail"])
+
     # 2. Find the Compile menu item in VBE Debug menu (ID 578).
     compile_item = None
+    compile_enabled = None
     try:
         debug_menu = app.VBE.CommandBars("Menu Bar").Controls("Debug")
         for i in range(1, debug_menu.Controls.Count + 1):
@@ -605,6 +684,11 @@ def ac_compile_vba(db_path: str, timeout: Optional[int] = None) -> dict:
             if "compil" in ctrl.Caption.lower().replace("&", ""):
                 compile_item = ctrl
                 break
+        if compile_item is not None:
+            try:
+                compile_enabled = bool(compile_item.Enabled)
+            except Exception:
+                pass
     except Exception:
         log.warning("Could not find VBE Debug > Compile menu item")
 
@@ -629,18 +713,35 @@ def ac_compile_vba(db_path: str, timeout: Optional[int] = None) -> dict:
     # can't hang the tool indefinitely or cut the watchdog before it sees
     # the dialog.
     grace = 2 if timeout is None else max(1, min(int(timeout), 30))
+    # A disabled menu item means Execute() would raise or no-op — fall back
+    # to RunCommand instead of triggering the failure we know about.
+    trigger = None
     try:
-        if compile_item:
+        if compile_item is not None and compile_enabled is not False:
+            trigger = "vbe_debug_menu"
             compile_item.Execute()
         else:
+            trigger = "runcommand"
             app.RunCommand(AC_CMD_COMPILE)
         # Give watchdog time to catch any late async dialog.
         time.sleep(grace)
     except Exception as exc:
+        # A genuine compile error surfaces as a DIALOG (handled below), not
+        # as an exception here.  An exception from the trigger itself almost
+        # always means the command was unavailable (disabled menu item, no
+        # code pane, VBE focus lost) — i.e. the compile never ran.  Say so
+        # instead of implying the VBA code is broken.
         err_loc = _get_vbe_error_location(app)
         result = {
             "status": "error",
-            "error_detail": f"VBA compilation error: {exc}",
+            "error_detail": (
+                f"Could not run the compile command (via {trigger}): {exc}. "
+                "This usually means the command was unavailable — NOT that "
+                "the VBA code has errors. Verify with Debug > Compile in "
+                "the VBE."
+            ),
+            "trigger": trigger,
+            "code_pane": pane_info,
         }
         if err_loc:
             result["error_location"] = err_loc
@@ -687,11 +788,26 @@ def ac_compile_vba(db_path: str, timeout: Optional[int] = None) -> dict:
                                    + "\n".join(detail_lines),
                     "errors": block_errors[:10],
                 }
+            # No dialog, no block mismatches, yet IsCompiled is False.  This
+            # is ambiguous: either a real dialog-less compile failure
+            # (missing reference, undeclared variable, type mismatch) or the
+            # compile command silently never ran (the state was forced dirty
+            # in step 0b, so a no-op trigger always lands here).  Report the
+            # ambiguity honestly — the old message blamed the user's code
+            # unconditionally and was a repeated false alarm in the field.
             return {
                 "status": "error",
-                "error_detail": "VBA project is NOT compiled. "
-                                "No block mismatches found — the error may be a "
-                                "missing reference, undeclared variable, or type mismatch.",
+                "error_detail": (
+                    "IsCompiled=False after triggering compile, but no error "
+                    "dialog appeared and no block mismatches were found. "
+                    "Either the project has a dialog-less compile error "
+                    "(missing reference, undeclared variable, type mismatch) "
+                    "— or the compile command did not actually run. "
+                    "Cross-check with Debug > Compile in the VBE before "
+                    "treating this as a code error."
+                ),
+                "trigger": trigger,
+                "code_pane": pane_info,
             }
     except Exception:
         pass

--- a/tests/test_compile_trigger.py
+++ b/tests/test_compile_trigger.py
@@ -1,0 +1,178 @@
+"""
+Pure-Python unit tests for the compile-trigger fix (false "NOT compiled").
+
+No COM / no Access needed — these exercise `_ensure_code_pane` in
+`mcp_access/compile.py` with fake VBE objects. The function must:
+  - prefer a STANDARD module's code pane (Type 1) over document modules,
+    regardless of enumeration order (showing a form module's pane is
+    harmless, but a standard module never has Design-view side effects);
+  - skip empty modules;
+  - fall back to a document module when no standard module has code;
+  - never raise: a project that can't be resolved or enumerated returns
+    ok=False with a diagnostic detail, because the caller treats the pane
+    activation as best-effort.
+
+The end-to-end behaviour (Execute() succeeding after pane activation, the
+honest trigger-failure report) requires a live Access instance and is
+covered by manual verification against a real database — see the PR notes.
+
+Run with:
+    python -m pytest tests/test_compile_trigger.py
+    python tests/test_compile_trigger.py            (plain — runs all asserts)
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import mcp_access.compile as compile_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes — just enough VBE surface for _ensure_code_pane
+# ---------------------------------------------------------------------------
+
+class _FakePane:
+    def __init__(self):
+        self.shown = False
+
+    def Show(self):
+        self.shown = True
+
+
+class _FakeCM:
+    def __init__(self, count_of_lines):
+        self.CountOfLines = count_of_lines
+        self.CodePane = _FakePane()
+
+
+class _FakeComp:
+    def __init__(self, name, comp_type, lines):
+        self.Name = name
+        self.Type = comp_type  # 1 = standard module, 100 = form/report doc
+        self.CodeModule = _FakeCM(lines)
+
+
+class _FakeProj:
+    def __init__(self, name, comps):
+        self.Name = name
+        self.VBComponents = comps
+
+
+class _RaisingProj:
+    """VBComponents access itself raises (broken reference / Trust Center)."""
+
+    Name = "BrokenProj"
+
+    @property
+    def VBComponents(self):
+        raise RuntimeError("VBComponents unavailable")
+
+
+def _run_with_project(proj_or_exc):
+    """Call _ensure_code_pane with _get_vb_project stubbed out."""
+    orig = compile_mod._get_vb_project
+    if isinstance(proj_or_exc, Exception):
+        def stub(app):
+            raise proj_or_exc
+    else:
+        def stub(app):
+            return proj_or_exc
+    compile_mod._get_vb_project = stub
+    try:
+        return compile_mod._ensure_code_pane(app=object())
+    finally:
+        compile_mod._get_vb_project = orig
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_prefers_standard_module_over_document_module():
+    form = _FakeComp("Form_frmMain", 100, lines=50)
+    std = _FakeComp("modUtils", 1, lines=10)
+    # Document module enumerates FIRST — the std module must still win.
+    proj = _FakeProj("MyProject", [form, std])
+    result = _run_with_project(proj)
+    assert result["ok"] is True
+    assert result["project"] == "MyProject"
+    assert "modUtils" in result["detail"]
+    assert std.CodeModule.CodePane.shown is True
+    assert form.CodeModule.CodePane.shown is False
+
+
+def test_skips_empty_modules():
+    empty_std = _FakeComp("modEmpty", 1, lines=0)
+    std = _FakeComp("modReal", 1, lines=3)
+    proj = _FakeProj("P", [empty_std, std])
+    result = _run_with_project(proj)
+    assert result["ok"] is True
+    assert "modReal" in result["detail"]
+    assert empty_std.CodeModule.CodePane.shown is False
+
+
+def test_falls_back_to_document_module_when_no_standard_has_code():
+    empty_std = _FakeComp("modEmpty", 1, lines=0)
+    form = _FakeComp("Form_frmMain", 100, lines=20)
+    proj = _FakeProj("P", [empty_std, form])
+    result = _run_with_project(proj)
+    assert result["ok"] is True
+    assert "Form_frmMain" in result["detail"]
+    assert form.CodeModule.CodePane.shown is True
+
+
+def test_no_code_anywhere_reports_not_ok_with_project_name():
+    proj = _FakeProj("EmptyProj", [_FakeComp("modEmpty", 1, lines=0)])
+    result = _run_with_project(proj)
+    assert result["ok"] is False
+    assert result["project"] == "EmptyProj"
+    assert "no component with code" in result["detail"]
+
+
+def test_get_vb_project_raising_is_not_fatal():
+    result = _run_with_project(RuntimeError("no project"))
+    assert result["ok"] is False
+    assert result["project"] is None
+    assert "no VBProject" in result["detail"]
+
+
+def test_vbcomponents_raising_is_not_fatal():
+    result = _run_with_project(_RaisingProj())
+    assert result["ok"] is False
+    assert result["project"] == "BrokenProj"
+    assert "not enumerable" in result["detail"]
+
+
+def test_component_raising_is_skipped_not_fatal():
+    class _BadComp:
+        Name = "bad"
+
+        @property
+        def Type(self):
+            raise RuntimeError("COM error")
+
+    std = _FakeComp("modOK", 1, lines=5)
+    proj = _FakeProj("P", [_BadComp(), std])
+    result = _run_with_project(proj)
+    assert result["ok"] is True
+    assert "modOK" in result["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Plain runner (no pytest dependency)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Fixes the long-standing false *"VBA project is NOT compiled … missing reference, undeclared variable, or type mismatch"* from `access_compile_vba`, and a modal dialog that could wedge `access_delete_object` mid-call.

## Commit 1 — `access_compile_vba`: stop misreporting a failed compile *trigger* as a compile *error*

### Root cause

`ac_compile_vba` deliberately dirties the project (step 0b) so `Application.IsCompiled` can serve as the success signal, then triggers compilation by `Execute()`-ing the VBE *Debug > Compile* menu item. That menu item acts on the **active** project and is only reliably enabled when one of its code panes has focus. With no pane active, the trigger could:

- raise `DISP_E_EXCEPTION` (-2147352567),
- silently no-op, or
- compile the wrong project entirely (after a decompile/compact cycle the active project is typically the `acwzmain` wizard library).

Every one of those paths left the deliberately-dirtied `IsCompiled=False` standing, which was then reported as a compile error in the *user's* code — while a manual Debug > Compile of the same project succeeded. This was a repeated false alarm in real use.

### Fix

- **`_ensure_code_pane()`** runs before the trigger: opens/activates a code pane of the *current database's* project (resolved via `_get_vb_project`, standard modules preferred since showing their pane has no Design-view side effects). This both enables the menu item and points it at the right project. Best-effort — it never raises, and its result is carried as a diagnostic.
- **Step 0b dirty-marking** now also resolves the project via `_get_vb_project` instead of `VBE.ActiveVBProject`, so it can no longer dirty `acwzmain` while `IsCompiled` is read from the user's project.
- A **disabled menu item falls back to `RunCommand`** instead of executing a control known to fail.
- **Honest error reporting**: an exception from the trigger is reported as *"could not run the compile command"* — explicitly not a code error — and the residual `IsCompiled=False`-with-no-dialog case now states both possible causes (dialog-less compile error vs. trigger no-op) and tells the caller to cross-check with Debug > Compile. Both results carry `trigger` and `code_pane` diagnostic fields.

## Commit 2 — `access_delete_object`: run `acCmdSaveAllModules` under the dialog watchdog

`RunCommand(280)` in `_save_all_modules` does not always report "not available now" as a trappable error 2046. When Access is not the foreground application — typically because the VBE has focus, e.g. right after `access_compile_vba` activated a code pane — it surfaces as a **modal dialog** that blocks the COM call until a human clicks OK. Seen in the field as a *"command 'SaveAllModules' isn't available"* box popping up during a routine module delete.

`RunCommand` is one of the blocking calls the dialog watchdog exists for, so it now runs under one. A dismissed dialog means the command did not run, so the per-module `DoCmd.Save` fallback executes instead of trusting a save that never happened. The watchdog thread is joined before the dismissal flag is read, since dismissing the dialog is exactly what unblocks the COM call — without the join the main thread could win that race.

## Tests

- `tests/test_compile_trigger.py` — 7 new pure-Python tests for the pane-selection logic (fake VBE objects, same convention as `test_vbe_fixes.py`): standard-module preference regardless of enumeration order, empty-module skipping, document-module fallback, and never-raise behaviour on broken projects/components.
- Full suite: **152 passed**.

## Manual verification (live Access, ~40-module production frontend)

The end-to-end behaviour needs a live Access instance, so it was verified manually:

1. **Clean project** (the false-alarm case): `access_compile_vba` → `{"status": "compiled"}`. Before the fix this machine reproducibly got the false "NOT compiled … missing reference" error while manual Debug > Compile succeeded.
2. **Deliberately broken module** (call to an undefined procedure): correct `"Sub or Function not defined"` with module/line/context in `error_location`.
3. **Compile-then-delete** (the commit-2 trigger condition): `access_compile_vba` (activates a code pane, VBE focused) immediately followed by `access_delete_object` on a scratch module → returned `{"action": "deleted"}` instantly, no modal dialog, no hang.

CHANGELOG entries are under a new `## Unreleased` heading; version bump and README changelog left for the release process per the repo's release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
